### PR TITLE
Fix conversation catch-up after backgrounding/reconnect; dismiss archived sessions

### DIFF
--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -50,6 +50,51 @@ struct HistoryLoadProgress: Equatable {
     var total: Int?
 }
 
+/// Pure staleness arithmetic for conversation history. One definition of
+/// "behind", with the activation-vs-reconcile policy made explicit instead of
+/// duplicated across call sites: activation may establish a first baseline,
+/// the per-`sessions`-frame reconcile only reloads on a concrete gap.
+enum ConversationReconciliation {
+    enum HistoryDecision: Equatable {
+        /// A load is already in flight, or local coverage is already current.
+        case skipLoading
+        /// Nothing is known locally — no completed baseline and no cached events.
+        case needsBaseline
+        /// Remote activity is strictly ahead of the newest covered activity.
+        case reloadHistory
+    }
+
+    /// A completed history baseline may subsequently be extended by the
+    /// subscribed live tail; both sources count as coverage. A session with
+    /// live events but no completed baseline is still covered up to its
+    /// newest event and only reloads when the remote summary moves past it.
+    static func historyDecision(
+        remoteLastActivity: Date,
+        syncedActivity: Date?,
+        latestLocalEventDate: Date?,
+        isHistoryLoading: Bool
+    ) -> HistoryDecision {
+        if isHistoryLoading { return .skipLoading }
+        guard let coveredActivity = [syncedActivity, latestLocalEventDate].compactMap({ $0 }).max() else {
+            return .needsBaseline
+        }
+        return remoteLastActivity > coveredActivity ? .reloadHistory : .skipLoading
+    }
+
+    /// Activation (conversation push, transport `hello`): the one path allowed
+    /// to establish a first baseline for a session with no local content.
+    static func activationShouldLoadHistory(_ decision: HistoryDecision) -> Bool {
+        decision != .skipLoading
+    }
+
+    /// Reconcile (every `sessions` frame): never fetches for a session it
+    /// cannot compare against local coverage, so a brand-new session's own
+    /// first send does not trigger a redundant full history fetch.
+    static func reconcileShouldLoadHistory(_ decision: HistoryDecision) -> Bool {
+        decision == .reloadHistory
+    }
+}
+
 @MainActor
 final class AppStore: ObservableObject {
     static let ungroupedWorkspaceID = "__ungrouped__"
@@ -123,6 +168,9 @@ final class AppStore: ObservableObject {
     /// This intentionally remains an in-memory cache: events are not persisted
     /// across launches, so a fresh process must fetch history again.
     private var historySyncedActivityDates: [String: Date] = [:]
+    /// Sessions whose disappearance from the authoritative list has already
+    /// been surfaced once, so repeated `sessions` frames stay silent.
+    private var missingConversationNoticeSessionIds: Set<String> = []
     private var conversationProjectionDrivers: [String: ConversationProjectionDriver] = [:]
     private var conversationTimelines: [String: ConversationTimeline] = [:]
     /// Invalidates an in-flight cold projection when a completed history
@@ -435,16 +483,17 @@ final class AppStore: ObservableObject {
         }
     }
 
+    private func historyDecision(for session: SessionSummary) -> ConversationReconciliation.HistoryDecision {
+        ConversationReconciliation.historyDecision(
+            remoteLastActivity: session.lastActivity,
+            syncedActivity: historySyncedActivityDates[session.id],
+            latestLocalEventDate: events[session.id]?.last?.date,
+            isHistoryLoading: historyLoadingSessionIds.contains(session.id)
+        )
+    }
+
     private func shouldRefreshHistory(for session: SessionSummary) -> Bool {
-        guard !historyLoadingSessionIds.contains(session.id) else { return false }
-        guard let syncedActivity = historySyncedActivityDates[session.id] else { return true }
-        // A completed history baseline may subsequently be extended by the
-        // subscribed live tail. Both sources are already present locally, so
-        // compare the remote summary against the newest covered activity
-        // instead of the older history-request timestamp alone.
-        let latestLocalActivity = events[session.id]?.last?.date ?? syncedActivity
-        let coveredActivity = max(syncedActivity, latestLocalActivity)
-        return session.lastActivity > coveredActivity
+        ConversationReconciliation.activationShouldLoadHistory(historyDecision(for: session))
     }
     func loadHistory(for sessionId: String, older: Bool = false) {
         guard gateway.state.isConnected else {
@@ -953,10 +1002,13 @@ final class AppStore: ObservableObject {
         if selectedSessionId == nil {
             selectedSessionId = id
             // The pushed "new conversation" destination has just become a
-            // real session. Align the activation key so a later transport
+            // real session. Align the prepared key so a later transport
             // generation (reconnect after backgrounding) can re-activate the
-            // pushed view instead of leaving it without a subscription.
+            // pushed view instead of leaving it without a subscription, and
+            // drop the stale sentinel activation so `prepared == active`
+            // holds again once the next activation runs.
             preparedConversationActivationKey = id
+            activeConversationActivationKey = nil
         }
         waitingForNewSession = false
         upsertSession(id: id, title: L10n.newSessionPlaceholderTitle)
@@ -1287,13 +1339,37 @@ final class AppStore: ObservableObject {
     /// *after* the transport re-subscribes and never replay the gap. Re-activation
     /// on `hello` runs before this response arrives and therefore compares
     /// against the stale summary; reconciling here, with the updated list,
-    /// closes that race. `shouldRefreshHistory` keeps an in-sync (or still
-    /// loading) conversation from fetching anything.
+    /// closes that race.
+    ///
+    /// Safe to call on every `sessions` frame: the decision helper
+    /// short-circuits in-flight loads, and sessions without established local
+    /// coverage only reload when remote activity is genuinely ahead — a
+    /// brand-new session's own first send therefore never triggers a
+    /// redundant full history fetch.
     private func reconcileOpenConversationWithRemoteState() {
+        // Only an already-open (prepared and selected) conversation
+        // reconciles; the `__new-conversation__` sentinel never matches a
+        // session id.
         guard let id = selectedSessionId,
-              preparedConversationActivationKey == id,
-              let session = sessions.first(where: { $0.id == id }),
-              shouldRefreshHistory(for: session) else { return }
+              preparedConversationActivationKey == id else { return }
+        guard let session = sessions.first(where: { $0.id == id }) else {
+            // The authoritative list no longer contains the open session: it
+            // was deleted or archived on another device. Cached content stays
+            // visible, and navigation chrome is immutable, so surface a notice
+            // instead of silently swapping a different session underneath the
+            // pushed title. Notify once per disappearance.
+            if missingConversationNoticeSessionIds.insert(id).inserted {
+                notice(
+                    String(localized: "notice.session.missing.title", defaultValue: "会话已不可用"),
+                    String(localized: "notice.session.missing.detail", defaultValue: "当前会话已在其他设备被删除或归档，显示的仍是本地缓存内容。"),
+                    sessionId: id,
+                    isError: true
+                )
+            }
+            return
+        }
+        missingConversationNoticeSessionIds.remove(id)
+        guard ConversationReconciliation.reconcileShouldLoadHistory(historyDecision(for: session)) else { return }
         loadHistory(for: id)
     }
     private func applyEvent(_ record: SessionEvent) {

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -674,6 +674,13 @@ final class AppStore: ObservableObject {
             }
             refreshRemoteState()
             refreshDefaultConfiguration()
+            // Every `hello` begins a new transport generation: the server-side
+            // subscription from the previous connection is gone. Background
+            // suspension tears the transport down without the failure callback
+            // that normally invalidates an activation, so reset it here to let
+            // the open conversation re-activate on the new generation —
+            // re-subscribing live events and catching up missed history.
+            activeConversationActivationKey = nil
             if preparedConversationActivationKey != nil {
                 Task { [weak self] in
                     guard let self else { return }
@@ -699,6 +706,7 @@ final class AppStore: ObservableObject {
         case "sessions":
             applyRemoteSessions(decodeItems(frame.items, as: GatewaySessionSummary.self))
             isRefreshing = false
+            reconcileOpenConversationWithRemoteState()
             notice(String(localized: "notice.sessions.synced", defaultValue: "会话列表已同步"), String(localized: "sessions.count", defaultValue: "\(sessions.count) 个会话"))
         case "history": applyHistoryRebased(frame)
         case "attachment": handleImageAttachment(frame)
@@ -942,7 +950,14 @@ final class AppStore: ObservableObject {
         if userInitiatedAgentWorkIsActive, backgroundAgentSessionID == nil {
             backgroundAgentSessionID = id
         }
-        if selectedSessionId == nil { selectedSessionId = id }
+        if selectedSessionId == nil {
+            selectedSessionId = id
+            // The pushed "new conversation" destination has just become a
+            // real session. Align the activation key so a later transport
+            // generation (reconnect after backgrounding) can re-activate the
+            // pushed view instead of leaving it without a subscription.
+            preparedConversationActivationKey = id
+        }
         waitingForNewSession = false
         upsertSession(id: id, title: L10n.newSessionPlaceholderTitle)
         if let index = sessions.firstIndex(where: { $0.id == id }) {
@@ -1265,6 +1280,21 @@ final class AppStore: ObservableObject {
         }
         sessions.removeAll { archivedSessionIds.contains($0.id) }
         sessions.sort { $0.lastActivity > $1.lastActivity }
+    }
+    /// A fresh session summary is the first authoritative signal that the open
+    /// conversation fell behind while the app was disconnected or backgrounded:
+    /// `subscribe` is only an event filter, so live frames carry output produced
+    /// *after* the transport re-subscribes and never replay the gap. Re-activation
+    /// on `hello` runs before this response arrives and therefore compares
+    /// against the stale summary; reconciling here, with the updated list,
+    /// closes that race. `shouldRefreshHistory` keeps an in-sync (or still
+    /// loading) conversation from fetching anything.
+    private func reconcileOpenConversationWithRemoteState() {
+        guard let id = selectedSessionId,
+              preparedConversationActivationKey == id,
+              let session = sessions.first(where: { $0.id == id }),
+              shouldRefreshHistory(for: session) else { return }
+        loadHistory(for: id)
     }
     private func applyEvent(_ record: SessionEvent) {
         let event = record.event

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 import UIKit
 
@@ -103,6 +104,44 @@ enum ConversationReconciliation {
     static func reconcileShouldLoadHistory(_ decision: HistoryDecision) -> Bool {
         decision == .reloadHistory
     }
+
+    /// What the reconcile should do with the currently open conversation
+    /// once a fresh `sessions` frame has arrived.
+    enum OpenConversationDisposition: Equatable {
+        /// No conversation is open (nothing selected, or the prepared key is
+        /// the `__new-conversation__` sentinel / another session).
+        case notOpen
+        /// The open session was archived on another device. Product decision:
+        /// archiving means the user does not want to see it anywhere, so the
+        /// app pops back to the workspace list instead of anchoring on it.
+        case dismissToWorkspace
+        /// The open session is absent from the authoritative list: deleted on
+        /// another device. Cached content stays visible under a notice.
+        case showMissingNotice
+        /// The session is present (or a locally created send not yet listed);
+        /// proceed to the staleness check.
+        case continueReconciling
+    }
+
+    static func openConversationDisposition(
+        selectedSessionId: String?,
+        preparedActivationKey: String?,
+        archivedSessionIds: Set<String>,
+        presentSessionIds: Set<String>,
+        unconfirmedLocallyCreatedSessionIds: Set<String>
+    ) -> OpenConversationDisposition {
+        guard let id = selectedSessionId, preparedActivationKey == id else { return .notOpen }
+        // Archived is checked before presence: an archived id necessarily
+        // references a real server-side session (it cannot appear in the
+        // archived list through any local race), and the server omits
+        // archived sessions from the active summary list, so it would
+        // otherwise fall through to the missing-notice branch.
+        if archivedSessionIds.contains(id) { return .dismissToWorkspace }
+        guard presentSessionIds.contains(id) || unconfirmedLocallyCreatedSessionIds.contains(id) else {
+            return .showMissingNotice
+        }
+        return .continueReconciling
+    }
 }
 
 @MainActor
@@ -164,6 +203,11 @@ final class AppStore: ObservableObject {
     @Published private(set) var pendingQuestionRequests: [GatewayPendingQuestionRequest] = []
     @Published private(set) var questionRequestStatuses: [String: GatewayQuestionRequestStatus] = [:]
     @Published private(set) var supportsImages = false
+    /// Increments when the open conversation must be dismissed (its session
+    /// was archived on another device). RootNavigationHost subscribes via
+    /// `conversationDismissalPublisher` and pops the navigation stack; the
+    /// resulting empty path drives `resumeWorkspace()` for cleanup.
+    @Published private(set) var conversationDismissalToken = 0
 
     let gateway = GatewayClient()
     private var pendingHistorySessionId: String?
@@ -298,6 +342,17 @@ final class AppStore: ObservableObject {
     var ungroupedSessions: [SessionSummary] {
         let groupedSessionIds = Set(workspaces.flatMap(\.sessionIds))
         return sessions.filter { !groupedSessionIds.contains($0.id) }
+    }
+
+    /// View-side subscription for `conversationDismissalToken`. `onReceive`
+    /// works on views that hold the store as an unobserved reference (the
+    /// equatable navigation host never re-evaluates its body, so onChange
+    /// would never fire).
+    var conversationDismissalPublisher: AnyPublisher<Void, Never> {
+        $conversationDismissalToken
+            .dropFirst()
+            .map { _ in () }
+            .eraseToAnyPublisher()
     }
 
     func connect() {
@@ -1388,29 +1443,48 @@ final class AppStore: ObservableObject {
     /// brand-new session's own first send therefore never triggers a
     /// redundant full history fetch.
     private func reconcileOpenConversationWithRemoteState(presentSessionIds: Set<String>) {
-        // Only an already-open (prepared and selected) conversation
-        // reconciles; the `__new-conversation__` sentinel never matches a
-        // session id.
-        guard let id = selectedSessionId,
-              preparedConversationActivationKey == id else { return }
-        guard presentSessionIds.contains(id) || unconfirmedLocallyCreatedSessionIds.contains(id) else {
+        guard let id = selectedSessionId else { return }
+        switch ConversationReconciliation.openConversationDisposition(
+            selectedSessionId: selectedSessionId,
+            preparedActivationKey: preparedConversationActivationKey,
+            archivedSessionIds: archivedSessionIds,
+            presentSessionIds: presentSessionIds,
+            unconfirmedLocallyCreatedSessionIds: unconfirmedLocallyCreatedSessionIds
+        ) {
+        case .notOpen:
+            return
+        case .dismissToWorkspace:
+            // The session was archived on another device: archiving is a
+            // "do not show me this anywhere" signal, so pop back to the
+            // workspace list instead of anchoring on it. Clear the activation
+            // state immediately so a subsequent frame cannot re-emit; the
+            // empty navigation path then drives resumeWorkspace() for the
+            // unsubscribe/refresh cleanup.
+            preparedConversationActivationKey = nil
+            activeConversationActivationKey = nil
+            missingConversationNoticeSessionIds.remove(id)
+            conversationDismissalToken &+= 1
+            return
+        case .showMissingNotice:
             // The authoritative frame no longer lists the open session: it
-            // was deleted or archived on another device. Cached content stays
-            // visible, and navigation chrome is immutable, so surface a notice
-            // instead of silently swapping a different session underneath the
-            // pushed title. Notify once per disappearance. A session created
-            // by this device's own send that no remote frame has confirmed
-            // yet is exempt — a pre-send snapshot response must not read as
-            // a deletion.
+            // was deleted on another device (archived was handled above).
+            // Cached content stays visible, and navigation chrome is
+            // immutable, so surface a notice instead of silently swapping a
+            // different session underneath the pushed title. Notify once per
+            // disappearance. A session created by this device's own send that
+            // no remote frame has confirmed yet is exempt — a pre-send
+            // snapshot response must not read as a deletion.
             if missingConversationNoticeSessionIds.insert(id).inserted {
                 notice(
                     String(localized: "notice.session.missing.title", defaultValue: "会话已不可用"),
-                    String(localized: "notice.session.missing.detail", defaultValue: "当前会话已在其他设备被删除或归档，显示的仍是本地缓存内容。"),
+                    String(localized: "notice.session.missing.detail", defaultValue: "当前会话已在其他设备被删除，显示的仍是本地缓存内容。"),
                     sessionId: id,
                     isError: true
                 )
             }
             return
+        case .continueReconciling:
+            break
         }
         missingConversationNoticeSessionIds.remove(id)
         guard let session = sessions.first(where: { $0.id == id }),

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -95,18 +95,20 @@ enum ConversationReconciliation {
     /// Activation (conversation push, transport `hello`): the one path allowed
     /// to establish a first baseline for a session with no local content.
     ///
-    /// A transport-generation re-activation (reconnect after backgrounding)
-    /// additionally forces a reload for already-covered sessions: the host's
-    /// `updatedAt` only advances on creation or a new HUMAN PROMPT
+    /// A transport-generation re-activation (reconnect after backgrounding),
+    /// or a plain push of a session whose turn was interrupted by one, forces
+    /// a reload for already-covered sessions: the host's `updatedAt` only
+    /// advances on creation or a new HUMAN PROMPT
     /// (sessionListUpdatedAt = max(createdAt, lastPromptAt)), so a session
-    /// whose turn kept streaming while the app was backgrounded compares as
+    /// whose turn kept streaming while the app was disconnected compares as
     /// "in sync" against a watermark derived from the prompt's timestamp —
-    /// even though output produced after backgrounding was never received.
+    /// even though output produced after the disconnect was never received.
     /// Gaps can only form while the transport is down, and every transport
-    /// death ends with a fresh `hello`, so forcing the fetch here closes
-    /// every gap the watermark cannot see. The seq-deduplicating rebase
-    /// makes a redundant fetch invisible, and loadHistory's own in-flight
-    /// guard prevents stacking.
+    /// death ends with a fresh `hello`, so forcing the fetch at re-activation
+    /// (and for interrupted turns pushed later) closes every gap class the
+    /// watermark cannot see. The seq-deduplicating rebase makes a redundant
+    /// fetch invisible, and loadHistory's own in-flight guard prevents
+    /// stacking.
     static func activationShouldLoadHistory(_ decision: HistoryDecision, isTransportReactivation: Bool = false) -> Bool {
         isTransportReactivation || decision != .skipLoading
     }
@@ -270,6 +272,13 @@ final class AppStore: ObservableObject {
     /// to the watermark comparison. See
     /// ConversationReconciliation.activationShouldLoadHistory.
     private var activationIsTransportReactivation = false
+    /// Sessions whose turn was still running when the last transport
+    /// generation ended (captured at `hello` from the last-known live list).
+    /// Pushing one of these forces a history reload even as a plain
+    /// navigation: the activity watermark is blind to streamed output
+    /// (updatedAt only advances on human prompts), so a session that was
+    /// mid-turn across a disconnect must not trust `.skipLoading`.
+    private var interruptedTurnSessionIds: Set<String> = []
     private var conversationProjectionDrivers: [String: ConversationProjectionDriver] = [:]
     private var conversationTimelines: [String: ConversationTimeline] = [:]
     /// Invalidates an in-flight cold projection when a completed history
@@ -581,20 +590,32 @@ final class AppStore: ObservableObject {
             gateway.requestAgentPresets()
         }
 
-        if let sessionID,
-           let session = sessions.first(where: { $0.id == sessionID }),
-           ConversationReconciliation.activationShouldLoadHistory(
-               historyDecision(for: session),
-               isTransportReactivation: isTransportReactivation
-           ) {
-            loadHistory(for: sessionID)
-        } else if let sessionID, isTransportReactivation,
-                  sessions.first(where: { $0.id == sessionID }) == nil {
-            // The summary list has not arrived yet on this generation (or the
-            // session is genuinely gone). Reconcile on the sessions frame
-            // disambiguates deletion, but the forced reload cannot wait for
-            // the stale summary: fetch for a known-id session regardless.
-            loadHistory(for: sessionID)
+        if let sessionID {
+            // A transport re-activation, or a session whose turn was still
+            // running when the previous generation ended, must reload even
+            // when the watermark says current: `updatedAt` only advances on
+            // human prompts, so streamed output missed while disconnected is
+            // invisible to the comparison. The one-shot removal keeps a
+            // single forced fetch per interruption; a still-running turn is
+            // re-captured by the next `hello` if the transport drops again.
+            let turnWasInterrupted = interruptedTurnSessionIds.remove(sessionID) != nil
+            if let session = sessions.first(where: { $0.id == sessionID }) {
+                if ConversationReconciliation.activationShouldLoadHistory(
+                    historyDecision(for: session),
+                    isTransportReactivation: isTransportReactivation || turnWasInterrupted
+                ) {
+                    loadHistory(for: sessionID)
+                }
+            } else if isTransportReactivation || turnWasInterrupted {
+                // No local summary on this generation yet (the fresh list has
+                // not arrived). The server-side session store is
+                // authoritative, so fetch for the known id directly: a
+                // genuinely deleted session answers with an error frame,
+                // which the reconcile disposition and error handling already
+                // surface. Waiting for the stale summary would reopen the
+                // very gap this reload exists to close.
+                loadHistory(for: sessionID)
+            }
         }
 
         await Task.yield()
@@ -618,9 +639,6 @@ final class AppStore: ObservableObject {
         )
     }
 
-    private func shouldRefreshHistory(for session: SessionSummary) -> Bool {
-        ConversationReconciliation.activationShouldLoadHistory(historyDecision(for: session))
-    }
     func loadHistory(for sessionId: String, older: Bool = false) {
         guard gateway.state.isConnected else {
             lastError = String(localized: "WebSocket 尚未连接，无法加载历史记录")
@@ -869,12 +887,17 @@ final class AppStore: ObservableObject {
             for staleSessionId in Array(historyLoadingSessionIds) {
                 finishHistoryLoading(staleSessionId)
             }
+            // Capture mid-turn sessions from the last-known live list BEFORE
+            // the fresh summaries land: their streamed output is invisible to
+            // the watermark (updatedAt only advances on human prompts), so a
+            // later navigation push must still force a history reload. The
+            // open-conversation path below handles the immediate case.
+            interruptedTurnSessionIds.formUnion(sessions.filter(\.isRunning).map(\.id))
             if preparedConversationActivationKey != nil {
                 // Mark this as a transport-generation re-activation so the
                 // open conversation force-reloads history: the activity
                 // watermark cannot see output that streamed while the
-                // transport was down (updatedAt advances only on new human
-                // prompts on the host side).
+                // transport was down.
                 activationIsTransportReactivation = true
                 Task { [weak self] in
                     guard let self else { return }
@@ -1220,6 +1243,9 @@ final class AppStore: ObservableObject {
             total: frame.hasMore == true ? nil : pageEventOffset + rawEvents.count
         )
 
+        let baselineEventCountAtLoadStart = events[id]?.count ?? 0
+        let loadKind = historyBatchKinds[id] ?? .latest
+
         Task { [weak self] in
             let normalized = await Task.detached(priority: .userInitiated) {
                 rawEvents.map { $0.normalized(sessionId: id) }
@@ -1317,15 +1343,34 @@ final class AppStore: ObservableObject {
             // Loading the newest batch establishes a tail watermark even when
             // older pages still exist. Reopening the session can therefore use
             // the in-memory pages immediately and only refresh when the remote
-            // session has genuinely changed.
-            if self.historyBatchKinds[id] == .latest,
-               let activity = self.sessions.first(where: { $0.id == id })?.lastActivity {
-                self.historySyncedActivityDates[id] = activity
+            // session has genuinely changed. Anchor to the NEWEST COVERED
+            // activity — the rebased tail's last event date — not the summary's
+            // `updatedAt`, which is frozen at the last human prompt and would
+            // knowingly understate coverage for a mid-turn catch-up.
+            if self.historyBatchKinds[id] == .latest {
+                let summaryActivity = self.sessions.first(where: { $0.id == id })?.lastActivity
+                let tailActivity = self.events[id]?.last?.date
+                let covered = [summaryActivity, tailActivity].compactMap { $0 }.max()
+                if let covered { self.historySyncedActivityDates[id] = covered }
+            }
+            // An interrupted turn may resume streaming right after this
+            // reload; drop it from the interrupted set only when the turn is
+            // genuinely over per the freshest signal we have.
+            if self.sessions.first(where: { $0.id == id })?.isRunning != true {
+                self.interruptedTurnSessionIds.remove(id)
             }
             self.finishHistoryLoading(id)
-            let byteDetail = totalBytes > 0 ? " · \(ByteCountFormatter.string(fromByteCount: Int64(totalBytes), countStyle: .file))" : ""
-            let moreDetail = self.historyHasMore[id] == true ? String(localized: "history.swipe.up.hint", defaultValue: " · 向上滑动加载更早记录") : ""
-            self.notice(String(localized: "notice.history.loaded", defaultValue: "历史记录已加载"), String(localized: "history.loaded.detail", defaultValue: "\(totalEvents) 个事件\(byteDetail)\(moreDetail)"), sessionId: id)
+            // Forced reconnect reloads frequently change nothing (seq-dedup).
+            // Only surface a notice when new events actually landed or more
+            // history is available, so a background->foreground cycle stays
+            // silent instead of toasting on every reconnect.
+            let finalEventCount = self.events[id]?.count ?? 0
+            let addedEvents = finalEventCount - baselineEventCountAtLoadStart
+            if addedEvents > 0 || self.historyHasMore[id] == true || loadKind == .older {
+                let byteDetail = totalBytes > 0 ? " · \(ByteCountFormatter.string(fromByteCount: Int64(totalBytes), countStyle: .file))" : ""
+                let moreDetail = self.historyHasMore[id] == true ? String(localized: "history.swipe.up.hint", defaultValue: " · 向上滑动加载更早记录") : ""
+                self.notice(String(localized: "notice.history.loaded", defaultValue: "历史记录已加载"), String(localized: "history.loaded.detail", defaultValue: "\(totalEvents) 个事件\(byteDetail)\(moreDetail)"), sessionId: id)
+            }
         }
     }
     private func finishHistoryLoading(_ sessionId: String) {

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -94,8 +94,21 @@ enum ConversationReconciliation {
 
     /// Activation (conversation push, transport `hello`): the one path allowed
     /// to establish a first baseline for a session with no local content.
-    static func activationShouldLoadHistory(_ decision: HistoryDecision) -> Bool {
-        decision != .skipLoading
+    ///
+    /// A transport-generation re-activation (reconnect after backgrounding)
+    /// additionally forces a reload for already-covered sessions: the host's
+    /// `updatedAt` only advances on creation or a new HUMAN PROMPT
+    /// (sessionListUpdatedAt = max(createdAt, lastPromptAt)), so a session
+    /// whose turn kept streaming while the app was backgrounded compares as
+    /// "in sync" against a watermark derived from the prompt's timestamp —
+    /// even though output produced after backgrounding was never received.
+    /// Gaps can only form while the transport is down, and every transport
+    /// death ends with a fresh `hello`, so forcing the fetch here closes
+    /// every gap the watermark cannot see. The seq-deduplicating rebase
+    /// makes a redundant fetch invisible, and loadHistory's own in-flight
+    /// guard prevents stacking.
+    static func activationShouldLoadHistory(_ decision: HistoryDecision, isTransportReactivation: Bool = false) -> Bool {
+        isTransportReactivation || decision != .skipLoading
     }
 
     /// Reconcile (every `sessions` frame): never fetches for a session it
@@ -250,6 +263,13 @@ final class AppStore: ObservableObject {
     /// and by resetOutstandingRequests on transport failure. Starts stale:
     /// cold launch has no archived knowledge at all.
     private var archivedSessionIdsStale = true
+    /// Set when a transport `hello` re-activates the prepared conversation.
+    /// The re-activation must reload history even for sessions the activity
+    /// watermark considers current: `updatedAt` only advances on new human
+    /// prompts, so streamed output missed while disconnected is invisible
+    /// to the watermark comparison. See
+    /// ConversationReconciliation.activationShouldLoadHistory.
+    private var activationIsTransportReactivation = false
     private var conversationProjectionDrivers: [String: ConversationProjectionDriver] = [:]
     private var conversationTimelines: [String: ConversationTimeline] = [:]
     /// Invalidates an in-flight cold projection when a completed history
@@ -541,6 +561,8 @@ final class AppStore: ObservableObject {
               gateway.state.isConnected else { return }
 
         activeConversationActivationKey = activationKey
+        let isTransportReactivation = activationIsTransportReactivation
+        activationIsTransportReactivation = false
         guard !Task.isCancelled else { return }
 
         if let sessionID {
@@ -561,7 +583,17 @@ final class AppStore: ObservableObject {
 
         if let sessionID,
            let session = sessions.first(where: { $0.id == sessionID }),
-           shouldRefreshHistory(for: session) {
+           ConversationReconciliation.activationShouldLoadHistory(
+               historyDecision(for: session),
+               isTransportReactivation: isTransportReactivation
+           ) {
+            loadHistory(for: sessionID)
+        } else if let sessionID, isTransportReactivation,
+                  sessions.first(where: { $0.id == sessionID }) == nil {
+            // The summary list has not arrived yet on this generation (or the
+            // session is genuinely gone). Reconcile on the sessions frame
+            // disambiguates deletion, but the forced reload cannot wait for
+            // the stale summary: fetch for a known-id session regardless.
             loadHistory(for: sessionID)
         }
 
@@ -838,6 +870,12 @@ final class AppStore: ObservableObject {
                 finishHistoryLoading(staleSessionId)
             }
             if preparedConversationActivationKey != nil {
+                // Mark this as a transport-generation re-activation so the
+                // open conversation force-reloads history: the activity
+                // watermark cannot see output that streamed while the
+                // transport was down (updatedAt advances only on new human
+                // prompts on the host side).
+                activationIsTransportReactivation = true
                 Task { [weak self] in
                     guard let self else { return }
                     await self.activatePreparedConversation(sessionID: self.selectedSessionId)

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -1594,10 +1594,14 @@ final class AppStore: ObservableObject {
         // the current frame's raw list. Filtering on the archived set alone
         // would let a stale set hide a session that was just un-archived.
         sessions.removeAll { archivedSessionIds.contains($0.id) && !presentSessionIds.contains($0.id) }
-        // Archived ids are definitively not pushable (the disposition pops
-        // them), so their interruption markers are dead weight — a session
-        // un-archived later is re-captured by the next hello if still running.
-        interruptedTurnSessionIds.subtract(archivedSessionIds)
+        // Interruption markers are deliberately NOT subtracted for archived
+        // ids here: `hello` is the only re-arming site, so a subtraction on
+        // every sessions frame would drop a still-meaningful marker for a
+        // session un-archived within the same transport generation (its
+        // missed tail would then never replay — the exact gap the marker
+        // exists to close). Archived sessions cannot be pushed (the
+        // disposition pops them), so an idle marker is harmless, and
+        // session-not-found clears markers for definitively deleted ones.
         sessions.sort { $0.lastActivity > $1.lastActivity }
     }
     /// A fresh session summary is the first authoritative signal that the open

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -238,11 +238,17 @@ final class AppStore: ObservableObject {
     /// handler re-runs the open-conversation disposition against this —
     /// the two responses of a reconnect's paired requests race.
     private var lastSessionsFramePresenceIds: Set<String> = []
-    /// True between a paired workspaces+sessions request and the workspaces
-    /// response, while the archived set may lag the summaries. The
-    /// missing-session notice is deferred while stale because the pending
-    /// workspaces frame disambiguates archived (pop) from deleted (notice).
-    /// Starts stale: cold launch has no archived knowledge at all.
+    /// True between a sessions request and the workspaces response that
+    /// pairs with it, while the archived set may lag the summaries. Armed
+    /// whenever sessions are requested — refreshRemoteState's paired
+    /// requests AND handleSent's unpaired follow-up — because the archived
+    /// set's freshness relative to an incoming summary list is otherwise
+    /// unknowable. The missing-session notice is deferred while stale
+    /// because the pending workspaces frame disambiguates archived (pop)
+    /// from deleted (notice). Cleared by a workspaces frame, by a gateway
+    /// error naming the workspaces request (its response will never come),
+    /// and by resetOutstandingRequests on transport failure. Starts stale:
+    /// cold launch has no archived knowledge at all.
     private var archivedSessionIdsStale = true
     private var conversationProjectionDrivers: [String: ConversationProjectionDriver] = [:]
     private var conversationTimelines: [String: ConversationTimeline] = [:]
@@ -862,7 +868,6 @@ final class AppStore: ObservableObject {
             notice(String(localized: "notice.workspaces.synced", defaultValue: "工作区已同步"), String(localized: "workspaces.count", defaultValue: "\(workspaces.count) 个工作区"))
         case "sessions":
             let remoteSummaries = decodeItems(frame.items, as: GatewaySessionSummary.self)
-            applyRemoteSessions(remoteSummaries)
             // The frame's raw id set is the authoritative presence signal —
             // the upsert-only local list cannot detect hard deletions. It is
             // deliberately NOT filtered through the (independently
@@ -871,6 +876,7 @@ final class AppStore: ObservableObject {
             // by construction, and filtering here would let a stale archived
             // set read an un-archived session as archived.
             let presentSessionIds = Set(remoteSummaries.map(\.sessionId))
+            applyRemoteSessions(remoteSummaries, presentSessionIds: presentSessionIds)
             lastSessionsFramePresenceIds = presentSessionIds
             unconfirmedLocallyCreatedSessionIds.subtract(presentSessionIds)
             isRefreshing = false
@@ -1025,6 +1031,12 @@ final class AppStore: ObservableObject {
         case "error":
             waitingForNewSession = false
             if frame.requestType == "directories" { directoryIsLoading = false }
+            if frame.requestType == "workspaces" {
+                // The paired workspaces response will never arrive; un-stick
+                // the staleness flag so missing-notices are not deferred
+                // until the next refresh cycle.
+                archivedSessionIdsStale = false
+            }
             if frame.requestType == "directory-create" {
                 directoryCreationIsLoading = false
                 pendingDirectoryCreationParentPath = nil
@@ -1140,6 +1152,11 @@ final class AppStore: ObservableObject {
         }
         notice(frame.command == nil ? String(localized: "消息已发送") : String(localized: "命令已执行"), frame.command?.displayText ?? String(localized: "session.preview.id", defaultValue: "\(id.prefix(12))…"), sessionId: id)
         gateway.subscribe(sessionId: id)
+        // This unpaired sessions request cannot know whether the archived
+        // set is still current; arm the staleness flag so the reconcile
+        // defers a missing-notice (which could be a live archive) until a
+        // workspaces frame lands or the flag is otherwise cleared.
+        archivedSessionIdsStale = true
         gateway.requestSessions()
         refreshSessionControls(for: id)
     }
@@ -1432,7 +1449,7 @@ final class AppStore: ObservableObject {
             conversationContentSessionIds.insert(sessionId)
         }
     }
-    private func applyRemoteSessions(_ remote: [GatewaySessionSummary]) {
+    private func applyRemoteSessions(_ remote: [GatewaySessionSummary], presentSessionIds: Set<String>) {
         for item in remote where !archivedSessionIds.contains(item.sessionId) {
             let fallback = item.cwd.map { URL(fileURLWithPath: $0).lastPathComponent }.flatMap { $0.isEmpty ? nil : $0 }
             let title = item.projectedTitle ?? fallback ?? L10n.remoteSessionTitle(item.sessionId.prefix(8))
@@ -1453,7 +1470,11 @@ final class AppStore: ObservableObject {
                 ))
             }
         }
-        sessions.removeAll { archivedSessionIds.contains($0.id) }
+        // Same combined invariant the open-conversation disposition uses:
+        // only drop a session when it is archived AND genuinely absent from
+        // the current frame's raw list. Filtering on the archived set alone
+        // would let a stale set hide a session that was just un-archived.
+        sessions.removeAll { archivedSessionIds.contains($0.id) && !presentSessionIds.contains($0.id) }
         sessions.sort { $0.lastActivity > $1.lastActivity }
     }
     /// A fresh session summary is the first authoritative signal that the open
@@ -1669,6 +1690,10 @@ final class AppStore: ObservableObject {
         for kind in Array(sessionControlLoadingKinds) { finishSessionControlRequest(kind) }
         for kind in Array(defaultConfigurationLoadingKinds) { finishDefaultConfigurationRequest(kind) }
         for id in Array(historyLoadingSessionIds) { finishHistoryLoading(id) }
+        // The transport generation that armed the staleness flag is gone;
+        // its workspaces response will never land. The next successful
+        // connection re-arms the flag via refreshRemoteState.
+        archivedSessionIdsStale = false
         directoryIsLoading = false
         directoryCreationIsLoading = false
         pendingDirectoryCreationParentPath = nil

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -616,6 +616,16 @@ final class AppStore: ObservableObject {
                 // very gap this reload exists to close.
                 loadHistory(for: sessionID)
             }
+            if turnWasInterrupted || isTransportReactivation,
+               !historyLoadingSessionIds.contains(sessionID),
+               !historyLoadingOlderSessionIds.contains(sessionID) {
+                // The forced fetch did not start (loadHistory dropped it on a
+                // disconnected transport). Re-arm so the interruption is not
+                // silently lost — a still-running turn may finish during the
+                // outage, after which no `hello` can re-capture it. When a
+                // load IS in flight, that load itself covers the gap.
+                interruptedTurnSessionIds.insert(sessionID)
+            }
         }
 
         await Task.yield()
@@ -691,6 +701,10 @@ final class AppStore: ObservableObject {
             let hasUsableLocalContent = !self.events[sessionId, default: []].isEmpty
                 || !self.renderedConversationItems[sessionId, default: []].isEmpty
             self.finishHistoryLoading(sessionId)
+            // The forced/interrupted catch-up fetch never completed: coverage
+            // is uncertain, so re-arm the interruption for the next push
+            // (bounded — one redundant fetch at most).
+            self.interruptedTurnSessionIds.insert(sessionId)
             self.scheduleConversationProjection(for: sessionId)
             if hasUsableLocalContent {
                 self.notice(
@@ -1109,6 +1123,10 @@ final class AppStore: ObservableObject {
             }
             if frame.requestType == "history", let id = frame.sessionId ?? pendingHistorySessionId {
                 finishHistoryLoading(id)
+                // The fetch failed; coverage is uncertain. Re-arm so a later
+                // push forces the catch-up again (bounded: one redundant
+                // fetch at most per failure).
+                interruptedTurnSessionIds.insert(id)
             }
             let detail = [frame.code, frame.message].compactMap { $0 }.joined(separator: ": ")
             if let requestType = frame.requestType,
@@ -1353,10 +1371,13 @@ final class AppStore: ObservableObject {
                 let covered = [summaryActivity, tailActivity].compactMap { $0 }.max()
                 if let covered { self.historySyncedActivityDates[id] = covered }
             }
-            // An interrupted turn may resume streaming right after this
-            // reload; drop it from the interrupted set only when the turn is
-            // genuinely over per the freshest signal we have.
-            if self.sessions.first(where: { $0.id == id })?.isRunning != true {
+            // Only a completed LATEST-tail load that sees the turn finished
+            // clears the interruption marker: pagination-only loads do not
+            // establish the tail, and a still-running turn must keep the
+            // marker so a later disconnect+push still forces the catch-up.
+            // Failure and timeout paths re-arm instead of clearing.
+            if loadKind == .latest,
+               self.sessions.first(where: { $0.id == id })?.isRunning != true {
                 self.interruptedTurnSessionIds.remove(id)
             }
             self.finishHistoryLoading(id)

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -131,12 +131,15 @@ enum ConversationReconciliation {
         unconfirmedLocallyCreatedSessionIds: Set<String>
     ) -> OpenConversationDisposition {
         guard let id = selectedSessionId, preparedActivationKey == id else { return .notOpen }
-        // Archived is checked before presence: an archived id necessarily
-        // references a real server-side session (it cannot appear in the
-        // archived list through any local race), and the server omits
-        // archived sessions from the active summary list, so it would
-        // otherwise fall through to the missing-notice branch.
-        if archivedSessionIds.contains(id) { return .dismissToWorkspace }
+        // Archived wins only when the id is genuinely absent from the current
+        // frame's raw presence set: the server omits archived sessions from
+        // the active summary list, so a raw-listed id is active by
+        // construction. This keeps a stale archived set (refreshed by the
+        // independent workspaces frame) from dismissing a session that was
+        // just un-archived on the desktop.
+        if archivedSessionIds.contains(id), !presentSessionIds.contains(id) {
+            return .dismissToWorkspace
+        }
         guard presentSessionIds.contains(id) || unconfirmedLocallyCreatedSessionIds.contains(id) else {
             return .showMissingNotice
         }
@@ -230,6 +233,17 @@ final class AppStore: ObservableObject {
     /// so a pre-send snapshot response cannot produce a false "deleted"
     /// notice for a conversation that just came to life.
     private var unconfirmedLocallyCreatedSessionIds: Set<String> = []
+    /// Raw session-id presence from the most recent `sessions` frame. The
+    /// `workspaces` frame refreshes the archived set independently, so its
+    /// handler re-runs the open-conversation disposition against this —
+    /// the two responses of a reconnect's paired requests race.
+    private var lastSessionsFramePresenceIds: Set<String> = []
+    /// True between a paired workspaces+sessions request and the workspaces
+    /// response, while the archived set may lag the summaries. The
+    /// missing-session notice is deferred while stale because the pending
+    /// workspaces frame disambiguates archived (pop) from deleted (notice).
+    /// Starts stale: cold launch has no archived knowledge at all.
+    private var archivedSessionIdsStale = true
     private var conversationProjectionDrivers: [String: ConversationProjectionDriver] = [:]
     private var conversationTimelines: [String: ConversationTimeline] = [:]
     /// Invalidates an in-flight cold projection when a completed history
@@ -442,6 +456,10 @@ final class AppStore: ObservableObject {
     }
     func refreshRemoteState() {
         guard gateway.state.isConnected else { return }
+        // The archived set is about to lag the summaries until the workspaces
+        // response lands; mark it so the reconcile can defer ambiguous
+        // missing-notices instead of guessing deleted vs archived.
+        archivedSessionIdsStale = true
         isRefreshing = true
         gateway.requestWorkspaces()
         gateway.requestSessions()
@@ -834,17 +852,26 @@ final class AppStore: ObservableObject {
                 selectedWorkspaceId = workspaces.first?.id ?? Self.ungroupedWorkspaceID
             }
             archivedSessionIds = Set(frame.archivedSessionIds ?? [])
+            archivedSessionIdsStale = false
+            // The archived set just refreshed. Re-run the open-conversation
+            // disposition against it and the most recent sessions presence:
+            // on reconnect the paired responses race, so the sessions frame
+            // may have deferred its missing-notice (or carried a stale
+            // archived set) until exactly this moment.
+            reconcileOpenConversationWithRemoteState(presentSessionIds: lastSessionsFramePresenceIds)
             notice(String(localized: "notice.workspaces.synced", defaultValue: "工作区已同步"), String(localized: "workspaces.count", defaultValue: "\(workspaces.count) 个工作区"))
         case "sessions":
             let remoteSummaries = decodeItems(frame.items, as: GatewaySessionSummary.self)
             applyRemoteSessions(remoteSummaries)
-            // The frame's own id set is the authoritative presence signal —
-            // the upsert-only local list cannot detect hard deletions.
-            let presentSessionIds = Set(
-                remoteSummaries
-                    .filter { !archivedSessionIds.contains($0.sessionId) }
-                    .map(\.sessionId)
-            )
+            // The frame's raw id set is the authoritative presence signal —
+            // the upsert-only local list cannot detect hard deletions. It is
+            // deliberately NOT filtered through the (independently
+            // refreshed, possibly stale) archived set: the server omits
+            // archived sessions from summaries, so a raw-listed id is active
+            // by construction, and filtering here would let a stale archived
+            // set read an un-archived session as archived.
+            let presentSessionIds = Set(remoteSummaries.map(\.sessionId))
+            lastSessionsFramePresenceIds = presentSessionIds
             unconfirmedLocallyCreatedSessionIds.subtract(presentSessionIds)
             isRefreshing = false
             reconcileOpenConversationWithRemoteState(presentSessionIds: presentSessionIds)
@@ -1457,13 +1484,15 @@ final class AppStore: ObservableObject {
             // The session was archived on another device: archiving is a
             // "do not show me this anywhere" signal, so pop back to the
             // workspace list instead of anchoring on it. Clear the activation
-            // state immediately so a subsequent frame cannot re-emit; the
-            // empty navigation path then drives resumeWorkspace() for the
-            // unsubscribe/refresh cleanup.
+            // and selection state immediately so a subsequent frame cannot
+            // re-emit; the empty navigation path then drives resumeWorkspace()
+            // for the unsubscribe/refresh cleanup.
             preparedConversationActivationKey = nil
             activeConversationActivationKey = nil
+            selectedSessionId = nil
             missingConversationNoticeSessionIds.remove(id)
-            conversationDismissalToken &+= 1
+            unconfirmedLocallyCreatedSessionIds.remove(id)
+            conversationDismissalToken += 1
             return
         case .showMissingNotice:
             // The authoritative frame no longer lists the open session: it
@@ -1474,6 +1503,13 @@ final class AppStore: ObservableObject {
             // disappearance. A session created by this device's own send that
             // no remote frame has confirmed yet is exempt — a pre-send
             // snapshot response must not read as a deletion.
+            guard !archivedSessionIdsStale else {
+                // A paired workspaces+sessions request is in flight and the
+                // archived set may lag this summary. Defer: the workspaces
+                // frame's re-run either pops (archived) or lands back here
+                // with a fresh set to notice (deleted).
+                return
+            }
             if missingConversationNoticeSessionIds.insert(id).inserted {
                 notice(
                     String(localized: "notice.session.missing.title", defaultValue: "会话已不可用"),

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -1595,11 +1595,13 @@ final class AppStore: ObservableObject {
         // would let a stale set hide a session that was just un-archived.
         sessions.removeAll { archivedSessionIds.contains($0.id) && !presentSessionIds.contains($0.id) }
         // Interruption markers are deliberately NOT subtracted for archived
-        // ids here: `hello` is the only re-arming site, so a subtraction on
-        // every sessions frame would drop a still-meaningful marker for a
-        // session un-archived within the same transport generation (its
-        // missed tail would then never replay — the exact gap the marker
-        // exists to close). Archived sessions cannot be pushed (the
+        // ids here: the arming sites are `hello` (mid-turn capture) and the
+        // catch-up FAILURE paths (error frame / timeout / dropped fetch) —
+        // none of which run for a session archived mid-turn and un-archived
+        // within the same transport generation, so a subtraction on every
+        // sessions frame would permanently drop a still-meaningful marker
+        // (its missed tail would then never replay — the exact gap the
+        // marker exists to close). Archived sessions cannot be pushed (the
         // disposition pops them), so an idle marker is harmless, and
         // session-not-found clears markers for definitively deleted ones.
         sessions.sort { $0.lastActivity > $1.lastActivity }

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -68,6 +68,10 @@ enum ConversationReconciliation {
     /// subscribed live tail; both sources count as coverage. A session with
     /// live events but no completed baseline is still covered up to its
     /// newest event and only reloads when the remote summary moves past it.
+    ///
+    /// The comparison is intentionally strict: equality counts as covered
+    /// (a >= comparison would reload on every frame), so same-timestamp
+    /// missed events only recover once remote activity moves strictly ahead.
     static func historyDecision(
         remoteLastActivity: Date,
         syncedActivity: Date?,
@@ -75,9 +79,15 @@ enum ConversationReconciliation {
         isHistoryLoading: Bool
     ) -> HistoryDecision {
         if isHistoryLoading { return .skipLoading }
-        guard let coveredActivity = [syncedActivity, latestLocalEventDate].compactMap({ $0 }).max() else {
-            return .needsBaseline
+        // Newest covered activity, without allocating a temporary array on
+        // every `sessions` frame (Optional is not Comparable).
+        let coveredActivity: Date?
+        if let synced = syncedActivity, let event = latestLocalEventDate {
+            coveredActivity = max(synced, event)
+        } else {
+            coveredActivity = syncedActivity ?? latestLocalEventDate
         }
+        guard let coveredActivity else { return .needsBaseline }
         return remoteLastActivity > coveredActivity ? .reloadHistory : .skipLoading
     }
 
@@ -171,6 +181,11 @@ final class AppStore: ObservableObject {
     /// Sessions whose disappearance from the authoritative list has already
     /// been surfaced once, so repeated `sessions` frames stay silent.
     private var missingConversationNoticeSessionIds: Set<String> = []
+    /// Sessions created by this device's own sends that no remote `sessions`
+    /// frame has listed yet. They are exempt from the missing-session check
+    /// so a pre-send snapshot response cannot produce a false "deleted"
+    /// notice for a conversation that just came to life.
+    private var unconfirmedLocallyCreatedSessionIds: Set<String> = []
     private var conversationProjectionDrivers: [String: ConversationProjectionDriver] = [:]
     private var conversationTimelines: [String: ConversationTimeline] = [:]
     /// Invalidates an in-flight cold projection when a completed history
@@ -562,6 +577,9 @@ final class AppStore: ObservableObject {
     func resumeWorkspace() {
         preparedConversationActivationKey = nil
         activeConversationActivationKey = nil
+        // The open conversation's lifecycle ended; its disappearance-notice
+        // bookkeeping should not outlive it.
+        missingConversationNoticeSessionIds.removeAll()
         gateway.subscribe(sessionId: nil)
         refreshRemoteState()
     }
@@ -730,6 +748,16 @@ final class AppStore: ObservableObject {
             // the open conversation re-activate on the new generation —
             // re-subscribing live events and catching up missed history.
             activeConversationActivationKey = nil
+            // History loads still marked in-flight also belong to the previous
+            // generation: the server never retransmits their responses, and
+            // without this reset the re-activation below would short-circuit
+            // to .skipLoading for up to the 20 s request timeout — leaving a
+            // first-baseline fetch that was interrupted by backgrounding
+            // permanently unfetched. Their timeout tasks see a cleared token
+            // and stay silent.
+            for staleSessionId in Array(historyLoadingSessionIds) {
+                finishHistoryLoading(staleSessionId)
+            }
             if preparedConversationActivationKey != nil {
                 Task { [weak self] in
                     guard let self else { return }
@@ -753,9 +781,18 @@ final class AppStore: ObservableObject {
             archivedSessionIds = Set(frame.archivedSessionIds ?? [])
             notice(String(localized: "notice.workspaces.synced", defaultValue: "工作区已同步"), String(localized: "workspaces.count", defaultValue: "\(workspaces.count) 个工作区"))
         case "sessions":
-            applyRemoteSessions(decodeItems(frame.items, as: GatewaySessionSummary.self))
+            let remoteSummaries = decodeItems(frame.items, as: GatewaySessionSummary.self)
+            applyRemoteSessions(remoteSummaries)
+            // The frame's own id set is the authoritative presence signal —
+            // the upsert-only local list cannot detect hard deletions.
+            let presentSessionIds = Set(
+                remoteSummaries
+                    .filter { !archivedSessionIds.contains($0.sessionId) }
+                    .map(\.sessionId)
+            )
+            unconfirmedLocallyCreatedSessionIds.subtract(presentSessionIds)
             isRefreshing = false
-            reconcileOpenConversationWithRemoteState()
+            reconcileOpenConversationWithRemoteState(presentSessionIds: presentSessionIds)
             notice(String(localized: "notice.sessions.synced", defaultValue: "会话列表已同步"), String(localized: "sessions.count", defaultValue: "\(sessions.count) 个会话"))
         case "history": applyHistoryRebased(frame)
         case "attachment": handleImageAttachment(frame)
@@ -1002,13 +1039,17 @@ final class AppStore: ObservableObject {
         if selectedSessionId == nil {
             selectedSessionId = id
             // The pushed "new conversation" destination has just become a
-            // real session. Align the prepared key so a later transport
-            // generation (reconnect after backgrounding) can re-activate the
-            // pushed view instead of leaving it without a subscription, and
-            // drop the stale sentinel activation so `prepared == active`
-            // holds again once the next activation runs.
+            // real session. Align the prepared key so the next transport
+            // generation's hello re-activation targets the real session id
+            // (rather than the __new-conversation__ sentinel) and can
+            // re-subscribe it, and drop the stale sentinel activation so
+            // `prepared == active` holds again once that activation runs.
+            // Track the id as locally created until a remote sessions frame
+            // confirms it, so a pre-send snapshot of the session list cannot
+            // read as a deletion.
             preparedConversationActivationKey = id
             activeConversationActivationKey = nil
+            unconfirmedLocallyCreatedSessionIds.insert(id)
         }
         waitingForNewSession = false
         upsertSession(id: id, title: L10n.newSessionPlaceholderTitle)
@@ -1346,18 +1387,21 @@ final class AppStore: ObservableObject {
     /// coverage only reload when remote activity is genuinely ahead — a
     /// brand-new session's own first send therefore never triggers a
     /// redundant full history fetch.
-    private func reconcileOpenConversationWithRemoteState() {
+    private func reconcileOpenConversationWithRemoteState(presentSessionIds: Set<String>) {
         // Only an already-open (prepared and selected) conversation
         // reconciles; the `__new-conversation__` sentinel never matches a
         // session id.
         guard let id = selectedSessionId,
               preparedConversationActivationKey == id else { return }
-        guard let session = sessions.first(where: { $0.id == id }) else {
-            // The authoritative list no longer contains the open session: it
+        guard presentSessionIds.contains(id) || unconfirmedLocallyCreatedSessionIds.contains(id) else {
+            // The authoritative frame no longer lists the open session: it
             // was deleted or archived on another device. Cached content stays
             // visible, and navigation chrome is immutable, so surface a notice
             // instead of silently swapping a different session underneath the
-            // pushed title. Notify once per disappearance.
+            // pushed title. Notify once per disappearance. A session created
+            // by this device's own send that no remote frame has confirmed
+            // yet is exempt — a pre-send snapshot response must not read as
+            // a deletion.
             if missingConversationNoticeSessionIds.insert(id).inserted {
                 notice(
                     String(localized: "notice.session.missing.title", defaultValue: "会话已不可用"),
@@ -1369,7 +1413,10 @@ final class AppStore: ObservableObject {
             return
         }
         missingConversationNoticeSessionIds.remove(id)
-        guard ConversationReconciliation.reconcileShouldLoadHistory(historyDecision(for: session)) else { return }
+        guard let session = sessions.first(where: { $0.id == id }),
+              ConversationReconciliation.reconcileShouldLoadHistory(historyDecision(for: session)) else { return }
+        // loadHistory re-checks the in-flight guard internally, so a race
+        // with the hello-triggered activation Task cannot double-load.
         loadHistory(for: id)
     }
     private func applyEvent(_ record: SessionEvent) {

--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -700,11 +700,14 @@ final class AppStore: ObservableObject {
             guard let self, self.historyRequestTokens[sessionId] == token else { return }
             let hasUsableLocalContent = !self.events[sessionId, default: []].isEmpty
                 || !self.renderedConversationItems[sessionId, default: []].isEmpty
+            let timedOutLoadKind = self.historyBatchKinds[sessionId]
             self.finishHistoryLoading(sessionId)
-            // The forced/interrupted catch-up fetch never completed: coverage
-            // is uncertain, so re-arm the interruption for the next push
-            // (bounded — one redundant fetch at most).
-            self.interruptedTurnSessionIds.insert(sessionId)
+            if timedOutLoadKind != .older {
+                // The tail fetch never completed; coverage is uncertain, so
+                // re-arm for the next push (bounded — one redundant fetch).
+                // Pagination timeouts leave the tail baseline untouched.
+                self.interruptedTurnSessionIds.insert(sessionId)
+            }
             self.scheduleConversationProjection(for: sessionId)
             if hasUsableLocalContent {
                 self.notice(
@@ -1122,11 +1125,23 @@ final class AppStore: ObservableObject {
                 finishDefaultConfigurationRequest(requestType)
             }
             if frame.requestType == "history", let id = frame.sessionId ?? pendingHistorySessionId {
+                // Capture the kind before finishHistoryLoading nils it.
+                let failedLoadKind = historyBatchKinds[id]
                 finishHistoryLoading(id)
-                // The fetch failed; coverage is uncertain. Re-arm so a later
-                // push forces the catch-up again (bounded: one redundant
-                // fetch at most per failure).
-                interruptedTurnSessionIds.insert(id)
+                if frame.code == "session-not-found" {
+                    // The session is gone; no tail exists to re-capture.
+                    // Clear instead of re-arming, or every later activation
+                    // of the (deleted) session repeats a doomed fetch.
+                    interruptedTurnSessionIds.remove(id)
+                } else if failedLoadKind != .older {
+                    // The tail fetch failed; coverage is uncertain. Re-arm so
+                    // a later push forces the catch-up again. Pagination-only
+                    // (.older) failures leave the tail baseline untouched and
+                    // must not re-arm. Accepted widening: a routine baseline
+                    // failure also re-arms — bounded to one redundant fetch
+                    // on the next push.
+                    interruptedTurnSessionIds.insert(id)
+                }
             }
             let detail = [frame.code, frame.message].compactMap { $0 }.joined(separator: ": ")
             if let requestType = frame.requestType,
@@ -1579,6 +1594,10 @@ final class AppStore: ObservableObject {
         // the current frame's raw list. Filtering on the archived set alone
         // would let a stale set hide a session that was just un-archived.
         sessions.removeAll { archivedSessionIds.contains($0.id) && !presentSessionIds.contains($0.id) }
+        // Archived ids are definitively not pushable (the disposition pops
+        // them), so their interruption markers are dead weight — a session
+        // un-archived later is re-captured by the next hello if still running.
+        interruptedTurnSessionIds.subtract(archivedSessionIds)
         sessions.sort { $0.lastActivity > $1.lastActivity }
     }
     /// A fresh session summary is the first authoritative signal that the open

--- a/DeepSeekHarnessMobile/Core/GatewayClient.swift
+++ b/DeepSeekHarnessMobile/Core/GatewayClient.swift
@@ -290,8 +290,23 @@ final class GatewayClient: ObservableObject {
         ])
     }
 
+    /// Test seam: unit tests drive AppStore's frame pipeline without a real
+    /// socket; sends are silently dropped and the connected state is pinned
+    /// instead of failing on the missing transport.
+    #if DEBUG
+    var _testSuppressTransportFailures = false
+
+    func _testSimulateConnected() {
+        _testSuppressTransportFailures = true
+        state = .connected
+    }
+    #endif
+
     private func send(_ object: [String: Any]) {
         guard let socket else {
+            #if DEBUG
+            if _testSuppressTransportFailures { return }
+            #endif
             state = .failed(String(localized: "state.websocket.not-connected", defaultValue: "WebSocket 尚未连接"))
             return
         }

--- a/DeepSeekHarnessMobile/Resources/Localizable.xcstrings
+++ b/DeepSeekHarnessMobile/Resources/Localizable.xcstrings
@@ -1121,6 +1121,40 @@
         }
       }
     },
+    "notice.session.missing.detail" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This session was deleted or archived on another device; the view now shows locally cached content only."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前会话已在其他设备被删除或归档，显示的仍是本地缓存内容。"
+          }
+        }
+      }
+    },
+    "notice.session.missing.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session unavailable"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会话已不可用"
+          }
+        }
+      }
+    },
     "notice.sessions.synced" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/DeepSeekHarnessMobile/Resources/Localizable.xcstrings
+++ b/DeepSeekHarnessMobile/Resources/Localizable.xcstrings
@@ -1127,13 +1127,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This session was deleted or archived on another device; the view now shows locally cached content only."
+            "value" : "This session was deleted on another device; the view now shows locally cached content only."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "当前会话已在其他设备被删除或归档，显示的仍是本地缓存内容。"
+            "value" : "当前会话已在其他设备被删除，显示的仍是本地缓存内容。"
           }
         }
       }

--- a/DeepSeekHarnessMobile/Views/RootView.swift
+++ b/DeepSeekHarnessMobile/Views/RootView.swift
@@ -57,6 +57,13 @@ private struct RootNavigationHost: View, Equatable {
         .onChange(of: navigationPath) { _, path in
             if path.isEmpty { store.resumeWorkspace() }
         }
+        .onReceive(store.conversationDismissalPublisher) { _ in
+            // The open session was archived on another device; pop to the
+            // workspace list. The emptied path triggers the observer above,
+            // which resumes workspace subscriptions and refreshes.
+            guard !navigationPath.isEmpty else { return }
+            navigationPath.removeAll()
+        }
     }
 
     @ViewBuilder

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -576,6 +576,47 @@ final class ConversationReactivationTests: XCTestCase {
         )
     }
 
+    /// The error-frame path distinguishes definitive deletion from
+    /// transient failure: `session-not-found` clears the interruption
+    /// marker (no tail can ever be re-captured — a re-armed marker would
+    /// doom every later activation to a failing fetch), while other history
+    /// errors re-arm it. Observable via push behavior: the watermark in
+    /// these fixtures says .skipLoading, so a forced load can only come
+    /// from the marker.
+    func testSessionNotFoundErrorClearsInterruptionMarker() async {
+        let store = makeCoveredStore(running: true)
+        store.gateway.onFrame?(GatewayFrame(kind: "hello", protocol: 3, authenticated: true))
+        store.gateway.onFrame?(GatewayFrame(
+            kind: "error",
+            sessionId: "s1",
+            code: "session-not-found",
+            requestType: "history"
+        ))
+        store.prepareConversation(for: store.sessions[0])
+        await store.activatePreparedConversation(sessionID: "s1")
+        XCTAssertFalse(
+            store.historyLoadingSessionIds.contains("s1"),
+            "a definitively deleted session must not re-arm: no doomed fetch on later pushes"
+        )
+    }
+
+    func testTransientHistoryErrorReArmsInterruptionMarker() async {
+        let store = makeCoveredStore(running: true)
+        store.gateway.onFrame?(GatewayFrame(kind: "hello", protocol: 3, authenticated: true))
+        store.gateway.onFrame?(GatewayFrame(
+            kind: "error",
+            sessionId: "s1",
+            code: "upstream-unavailable",
+            requestType: "history"
+        ))
+        store.prepareConversation(for: store.sessions[0])
+        await store.activatePreparedConversation(sessionID: "s1")
+        XCTAssertTrue(
+            store.historyLoadingSessionIds.contains("s1"),
+            "a transient tail-fetch failure must re-arm so the next push retries the catch-up"
+        )
+    }
+
     func testInterruptedTurnForcesReloadOnLaterPlainPush() async {
         let store = makeCoveredStore(running: true)
         // Reconnect with the workspace list showing (no conversation open):

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -400,6 +400,39 @@ final class ConversationReconciliationTests: XCTestCase {
         XCTAssertEqual(ConversationReconciliation.reconcileShouldLoadHistory(.skipLoading), false)
     }
 
+    func testTransportReactivationForcesHistoryReload() {
+        // The host's updatedAt only advances on creation or a new human
+        // prompt, so a session whose turn streamed while the transport was
+        // down compares as "current" (.skipLoading) despite the missed
+        // output. A transport-generation re-activation must reload anyway;
+        // loadHistory's in-flight guard prevents stacking.
+        XCTAssertEqual(
+            ConversationReconciliation.activationShouldLoadHistory(
+                .skipLoading, isTransportReactivation: true
+            ),
+            true
+        )
+        XCTAssertEqual(
+            ConversationReconciliation.activationShouldLoadHistory(
+                .needsBaseline, isTransportReactivation: true
+            ),
+            true
+        )
+        XCTAssertEqual(
+            ConversationReconciliation.activationShouldLoadHistory(
+                .reloadHistory, isTransportReactivation: true
+            ),
+            true
+        )
+        // Plain navigation pushes keep the watermark policy.
+        XCTAssertEqual(
+            ConversationReconciliation.activationShouldLoadHistory(
+                .skipLoading, isTransportReactivation: false
+            ),
+            false
+        )
+    }
+
     // MARK: - Open-conversation disposition (archived pop / missing notice)
 
     private func disposition(

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -421,21 +421,39 @@ final class ConversationReconciliationTests: XCTestCase {
     func testDispositionRequiresOpenConversation() {
         XCTAssertEqual(disposition(selected: nil), .notOpen)
         // Prepared key pointing at another destination (or the
-        // __new-conversation__ sentinel) means no open conversation to act on.
+        // __new-conversation__ sentinel, which never equals a session id)
+        // means no open conversation to act on.
         XCTAssertEqual(disposition(selected: "s1", prepared: "s2"), .notOpen)
         XCTAssertEqual(disposition(selected: "s1", prepared: nil), .notOpen)
+        XCTAssertEqual(
+            disposition(selected: "s1", prepared: "__new-conversation__"),
+            .notOpen
+        )
     }
 
     func testArchivedSessionDismissesToWorkspace() {
-        // Archiving is checked first: it wins even when the archived session
-        // is naturally absent from the active presence set (the server omits
-        // archived sessions from summaries).
+        // Archived wins when the id is genuinely absent from the raw presence
+        // set (the server omits archived sessions from summaries, so a fresh
+        // frame always produces this cell).
         XCTAssertEqual(
             disposition(selected: "s1", archived: ["s1"], present: []),
             .dismissToWorkspace
         )
+        // Archived + raw-present is the stale-set cell (un-archived on the
+        // desktop, workspaces frame not yet re-fetched): a raw-listed id is
+        // active by construction, so it must NOT dismiss.
         XCTAssertEqual(
             disposition(selected: "s1", archived: ["s1"], present: ["s1"]),
+            .continueReconciling
+        )
+    }
+
+    func testArchivedWinsOverUnconfirmedLocallyCreated() {
+        // A locally created session can legitimately end up archived before
+        // any sessions frame lists it; the archived check precedes the
+        // unconfirmed exemption.
+        XCTAssertEqual(
+            disposition(selected: "s1", archived: ["s1"], present: [], unconfirmed: ["s1"]),
             .dismissToWorkspace
         )
     }

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -331,3 +331,69 @@ final class GatewayProtocolTests: XCTestCase {
         XCTAssertNil(GatewayQuestionAnswer(id: "empty", selected: [], custom: "  \n ").custom)
     }
 }
+
+/// Guards the pure staleness arithmetic that decides when the open
+/// conversation re-fetches history after a reconnect/background gap: the
+/// backgrounding staleness bug (session list refreshed, chat never caught
+/// up) must stay reproducible in a unit test.
+final class ConversationReconciliationTests: XCTestCase {
+    private func decision(
+        remote: Date,
+        synced: Date?,
+        latestEvent: Date?,
+        loading: Bool = false
+    ) -> ConversationReconciliation.HistoryDecision {
+        ConversationReconciliation.historyDecision(
+            remoteLastActivity: remote,
+            syncedActivity: synced,
+            latestLocalEventDate: latestEvent,
+            isHistoryLoading: loading
+        )
+    }
+
+    func testInFlightLoadAlwaysSkips() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let t1 = t0.addingTimeInterval(60)
+        let t2 = t0.addingTimeInterval(120)
+        XCTAssertEqual(decision(remote: t2, synced: t1, latestEvent: t1, loading: true), .skipLoading)
+        XCTAssertEqual(decision(remote: t2, synced: nil, latestEvent: nil, loading: true), .skipLoading)
+    }
+
+    func testNoLocalKnowledgeNeedsBaseline() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let t1 = t0.addingTimeInterval(60)
+        // No baseline and no cached events: nothing to compare against.
+        XCTAssertEqual(decision(remote: t1, synced: nil, latestEvent: nil), .needsBaseline)
+    }
+
+    func testRemoteAheadOfCoverageReloads() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let t1 = t0.addingTimeInterval(60)
+        let t2 = t0.addingTimeInterval(120)
+        XCTAssertEqual(decision(remote: t2, synced: t1, latestEvent: nil), .reloadHistory)
+        // Live events without a completed baseline still count as coverage,
+        // so only a genuinely newer remote summary reloads.
+        XCTAssertEqual(decision(remote: t2, synced: nil, latestEvent: t1), .reloadHistory)
+    }
+
+    func testCurrentCoverageSkips() {
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let t1 = t0.addingTimeInterval(60)
+        XCTAssertEqual(decision(remote: t1, synced: t1, latestEvent: nil), .skipLoading)
+        XCTAssertEqual(decision(remote: t0, synced: nil, latestEvent: t1), .skipLoading)
+        // Equal timestamps count as covered, not behind.
+        XCTAssertEqual(decision(remote: t1, synced: nil, latestEvent: t1), .skipLoading)
+        XCTAssertEqual(decision(remote: t1, synced: t0, latestEvent: t1), .skipLoading)
+    }
+
+    func testActivationAndReconcilePoliciesDifferOnlyOnBaseline() {
+        // Activation (conversation push / transport hello) may establish a
+        // first baseline; reconcile (every sessions frame) may not.
+        XCTAssertEqual(ConversationReconciliation.activationShouldLoadHistory(.needsBaseline), true)
+        XCTAssertEqual(ConversationReconciliation.reconcileShouldLoadHistory(.needsBaseline), false)
+        XCTAssertEqual(ConversationReconciliation.activationShouldLoadHistory(.reloadHistory), true)
+        XCTAssertEqual(ConversationReconciliation.reconcileShouldLoadHistory(.reloadHistory), true)
+        XCTAssertEqual(ConversationReconciliation.activationShouldLoadHistory(.skipLoading), false)
+        XCTAssertEqual(ConversationReconciliation.reconcileShouldLoadHistory(.skipLoading), false)
+    }
+}

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -360,10 +360,11 @@ final class ConversationReconciliationTests: XCTestCase {
     }
 
     func testNoLocalKnowledgeNeedsBaseline() {
-        let t0 = Date(timeIntervalSince1970: 1_000)
-        let t1 = t0.addingTimeInterval(60)
         // No baseline and no cached events: nothing to compare against.
-        XCTAssertEqual(decision(remote: t1, synced: nil, latestEvent: nil), .needsBaseline)
+        XCTAssertEqual(
+            decision(remote: Date(timeIntervalSince1970: 1_060), synced: nil, latestEvent: nil),
+            .needsBaseline
+        )
     }
 
     func testRemoteAheadOfCoverageReloads() {
@@ -381,6 +382,8 @@ final class ConversationReconciliationTests: XCTestCase {
         let t1 = t0.addingTimeInterval(60)
         XCTAssertEqual(decision(remote: t1, synced: t1, latestEvent: nil), .skipLoading)
         XCTAssertEqual(decision(remote: t0, synced: nil, latestEvent: t1), .skipLoading)
+        // A completed baseline ahead of the remote summary also short-circuits.
+        XCTAssertEqual(decision(remote: t0, synced: t1, latestEvent: nil), .skipLoading)
         // Equal timestamps count as covered, not behind.
         XCTAssertEqual(decision(remote: t1, synced: nil, latestEvent: t1), .skipLoading)
         XCTAssertEqual(decision(remote: t1, synced: t0, latestEvent: t1), .skipLoading)

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -505,3 +505,77 @@ final class ConversationReconciliationTests: XCTestCase {
         XCTAssertEqual(disposition(selected: "s1"), .continueReconciling)
     }
 }
+
+/// Store-level regression tests for the transport-reactivation state machine:
+/// `hello` arms the forced reload, the re-activation consumes it, and the
+/// interrupted-turn set covers the list-then-push variant. These pin the
+/// integration behavior the pure-policy tests cannot reach (the original
+/// TestFlight regression was exactly here: watermark policy + missing
+/// forced reload).
+@MainActor
+final class ConversationReactivationTests: XCTestCase {
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "gateway.sessions")
+        UserDefaults.standard.removeObject(forKey: "gateway.selectedWorkspaceId")
+    }
+
+    /// Covered session (local events newer than the summary's frozen
+    /// `updatedAt`-derived activity) so the watermark decision is .skipLoading.
+    private func makeCoveredStore(sessionID: String = "s1", running: Bool = false) -> AppStore {
+        let store = AppStore()
+        store.sessions = [SessionSummary(
+            id: sessionID,
+            title: "T",
+            lastActivity: Date(timeIntervalSince1970: 1_000),
+            isRunning: running,
+            hasUnread: false,
+            agentPreset: nil
+        )]
+        store.events[sessionID] = [SessionEvent(
+            sessionId: sessionID,
+            seq: 4,
+            time: 2_000,
+            event: GatewayEvent(type: "assistant/message", text: "tail")
+        )]
+        store.gateway._testSimulateConnected()
+        return store
+    }
+
+    func testHelloReactivationForcesHistoryReloadDespiteCurrentWatermark() async {
+        let store = makeCoveredStore()
+        store.prepareConversation(for: store.sessions[0])
+        store.gateway.onFrame?(GatewayFrame(kind: "hello", protocol: 3, capabilities: ["images"], authenticated: true))
+        // Let the spawned re-activation Task run through its yield points.
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertTrue(
+            store.historyLoadingSessionIds.contains("s1"),
+            "transport re-activation must reload history even when the watermark says current"
+        )
+    }
+
+    func testPlainPushKeepsWatermarkPolicy() async {
+        let store = makeCoveredStore()
+        store.prepareConversation(for: store.sessions[0])
+        await store.activatePreparedConversation(sessionID: "s1")
+        XCTAssertFalse(
+            store.historyLoadingSessionIds.contains("s1"),
+            "a plain navigation push with current coverage must not fetch (no flag leak from any prior generation)"
+        )
+    }
+
+    func testInterruptedTurnForcesReloadOnLaterPlainPush() async {
+        let store = makeCoveredStore(running: true)
+        // Reconnect with the workspace list showing (no conversation open):
+        // hello captures the mid-turn session into the interrupted set.
+        store.gateway.onFrame?(GatewayFrame(kind: "hello", protocol: 3, authenticated: true))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        // The user now pushes the still-mid-turn session as a PLAIN
+        // navigation; the watermark is blind to its streamed tail.
+        store.prepareConversation(for: store.sessions[0])
+        await store.activatePreparedConversation(sessionID: "s1")
+        XCTAssertTrue(
+            store.historyLoadingSessionIds.contains("s1"),
+            "an interrupted turn must force a history reload on a later plain push"
+        )
+    }
+}

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -541,14 +541,27 @@ final class ConversationReactivationTests: XCTestCase {
         return store
     }
 
+    /// Bounded polling instead of a fixed sleep: the spawned re-activation
+    /// Task crosses yield points with no wall-clock guarantee under CI load.
+    private func waitFor(
+        _ condition: @MainActor () -> Bool,
+        timeout: TimeInterval = 2
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(nanoseconds: 25_000_000)
+        }
+        return condition()
+    }
+
     func testHelloReactivationForcesHistoryReloadDespiteCurrentWatermark() async {
         let store = makeCoveredStore()
         store.prepareConversation(for: store.sessions[0])
         store.gateway.onFrame?(GatewayFrame(kind: "hello", protocol: 3, capabilities: ["images"], authenticated: true))
-        // Let the spawned re-activation Task run through its yield points.
-        try? await Task.sleep(nanoseconds: 300_000_000)
+        let loaded = await waitFor { store.historyLoadingSessionIds.contains("s1") }
         XCTAssertTrue(
-            store.historyLoadingSessionIds.contains("s1"),
+            loaded,
             "transport re-activation must reload history even when the watermark says current"
         )
     }
@@ -567,8 +580,9 @@ final class ConversationReactivationTests: XCTestCase {
         let store = makeCoveredStore(running: true)
         // Reconnect with the workspace list showing (no conversation open):
         // hello captures the mid-turn session into the interrupted set.
+        // The interrupted-turn capture is synchronous inside onFrame, so no
+        // wait is needed before the push.
         store.gateway.onFrame?(GatewayFrame(kind: "hello", protocol: 3, authenticated: true))
-        try? await Task.sleep(nanoseconds: 200_000_000)
         // The user now pushes the still-mid-turn session as a PLAIN
         // navigation; the watermark is blind to its streamed tail.
         store.prepareConversation(for: store.sessions[0])

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -601,7 +601,9 @@ final class ConversationReactivationTests: XCTestCase {
     }
 
     func testTransientHistoryErrorReArmsInterruptionMarker() async {
-        let store = makeCoveredStore(running: true)
+        // running: false — hello captures NOTHING here, so the only thing
+        // that can arm the marker is the error-frame re-arm this test pins.
+        let store = makeCoveredStore()
         store.gateway.onFrame?(GatewayFrame(kind: "hello", protocol: 3, authenticated: true))
         store.gateway.onFrame?(GatewayFrame(
             kind: "error",

--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -399,4 +399,58 @@ final class ConversationReconciliationTests: XCTestCase {
         XCTAssertEqual(ConversationReconciliation.activationShouldLoadHistory(.skipLoading), false)
         XCTAssertEqual(ConversationReconciliation.reconcileShouldLoadHistory(.skipLoading), false)
     }
+
+    // MARK: - Open-conversation disposition (archived pop / missing notice)
+
+    private func disposition(
+        selected: String?,
+        prepared: String? = "s1",
+        archived: Set<String> = [],
+        present: Set<String> = ["s1"],
+        unconfirmed: Set<String> = []
+    ) -> ConversationReconciliation.OpenConversationDisposition {
+        ConversationReconciliation.openConversationDisposition(
+            selectedSessionId: selected,
+            preparedActivationKey: prepared,
+            archivedSessionIds: archived,
+            presentSessionIds: present,
+            unconfirmedLocallyCreatedSessionIds: unconfirmed
+        )
+    }
+
+    func testDispositionRequiresOpenConversation() {
+        XCTAssertEqual(disposition(selected: nil), .notOpen)
+        // Prepared key pointing at another destination (or the
+        // __new-conversation__ sentinel) means no open conversation to act on.
+        XCTAssertEqual(disposition(selected: "s1", prepared: "s2"), .notOpen)
+        XCTAssertEqual(disposition(selected: "s1", prepared: nil), .notOpen)
+    }
+
+    func testArchivedSessionDismissesToWorkspace() {
+        // Archiving is checked first: it wins even when the archived session
+        // is naturally absent from the active presence set (the server omits
+        // archived sessions from summaries).
+        XCTAssertEqual(
+            disposition(selected: "s1", archived: ["s1"], present: []),
+            .dismissToWorkspace
+        )
+        XCTAssertEqual(
+            disposition(selected: "s1", archived: ["s1"], present: ["s1"]),
+            .dismissToWorkspace
+        )
+    }
+
+    func testMissingSessionShowsNoticeOnlyWhenNotExempt() {
+        XCTAssertEqual(disposition(selected: "s1", present: []), .showMissingNotice)
+        // A locally created send not yet listed by any remote frame is exempt
+        // from the deletion notice (pre-send snapshot race).
+        XCTAssertEqual(
+            disposition(selected: "s1", present: [], unconfirmed: ["s1"]),
+            .continueReconciling
+        )
+    }
+
+    func testPresentSessionContinuesReconciling() {
+        XCTAssertEqual(disposition(selected: "s1"), .continueReconciling)
+    }
 }


### PR DESCRIPTION
## Problem

Returning to the app after backgrounding left the open conversation stale: the session list refreshed, but the chat never caught up with output the agent produced while the app was away. The only recovery was the manual 重新加载历史 item buried in the toolbar menu.

## Root cause — three stacked defects

1. **No re-subscribe after a transport generation change.** Backgrounding tears the socket down deliberately (`suspendTransportForBackground`, to avoid spurious error alerts), which bypasses the connection-failure callback that normally invalidates `activeConversationActivationKey`. The `hello`-driven re-activation therefore early-returned, the new transport never re-subscribed the open session, and no live events arrived at all.

2. **The activity watermark is blind to streamed output.** `sessions.list` summaries expose `updatedAt = max(createdAt, lastPromptAt)` — see `packages/api/session-controller/src/list.ts` in this repository (`lastPromptAt` folds only from `user/message` events with `source.kind === 'user'`). A turn that keeps streaming after backgrounding never moves `updatedAt`, so the reconcile compared a frozen timestamp against local coverage that already included newer streamed events, concluded "in sync", and never fetched. This is host behavior, not specific to any wrapper install — verified against this repo at `master`.

3. **New-conversation key misalignment.** After the first message created a session, `preparedConversationActivationKey` stayed `__new-conversation__` while `selectedSessionId` became the real id, so that pushed view could never re-activate either.

Additionally: `subscribe` is documented as an event filter only (PROTOCOL.md) — it never replays what was missed while disconnected. `history` is the only replay source, so fixing (1) alone would still have lost the gap.

## Fix

- `hello` resets the activation key and clears stale in-flight history-load flags from the previous generation, so the prepared destination re-activates on every new transport generation: re-subscribe + session controls + history.
- The re-activation **forces a history reload** for the open conversation. Gaps can only form while the transport is down, and every transport death ends with a fresh `hello`, so this closes every gap class the watermark cannot see — no polling, no protocol changes. The seq-deduplicating history rebase makes redundant fetches invisible, and `loadHistory`'s in-flight guard prevents stacking.
- `hello` also captures still-running sessions (`interruptedTurnSessionIds`) so the *list-then-push* variant is covered too: reconnect while on the workspace list, then open the mid-turn session — the push forces a reload even though the watermark says "current". Markers are one-shot (consumed on use), re-armed if the forced fetch fails/drops/times out, cleared once a completed latest-tail load sees the turn finished, and cleared on `session-not-found` so deleted sessions cannot doom-loop.
- New product behavior (deliberate): a session archived on another device pops the phone back to the workspace list — archiving means "don't show me this anywhere". Genuine deletion keeps the conversation visible under a "deleted on another device" notice with cached content, since navigation chrome is immutable.
- Plain navigation pushes keep the existing watermark policy, so quick in/out navigation still does not refetch.

## Behavior notes

- The catch-up never flashes a loading mask over cached content (the mask stays reserved for genuinely cold sessions).
- New user-facing strings are added in both zh-Hans and en.
- Accepted tradeoff: one bounded history fetch per background→foreground cycle while a conversation is open. Alternative considered: a seq-probe protocol extension — rejected to avoid protocol changes.
- The forced-reload error paths re-arm the interruption marker (bounded: one redundant fetch per failure); `session-not-found` clears it instead, so a deleted session cannot doom-loop.

## Tests

- `ConversationReconciliationTests` — pure decision matrix: history-decision cells (in-flight skip / needsBaseline / reload, current-coverage skip, strict-`>` equality), activation-vs-reconcile policies, transport-reactivation forcing, open-conversation disposition (archived precedence, missing-notice, unconfirmed locally-created exemption).
- `ConversationReactivationTests` — store-level state machine driven through the gateway frame pipeline: hello arms the forced reload despite `.skipLoading`, plain pushes keep the watermark policy, interrupted turns force reload on later pushes, history error frames clear/re-arm the marker by code. Uses a DEBUG-only `GatewayClient` transport seam (sends suppressed, connected state pinned) — no production surface changes.
- Full suite green: 4/4 classes (`xcodebuild test`, run `20260827-041802-40a4`). The line is also running on device as TestFlight v1.1.1 (build 3).

## Upstream-compatibility verification

The `updatedAt` semantics above were verified directly against this repository's `packages/api/session-controller/src/list.ts` at `master` (`updatedAt(session.header, metadata) = Math.max(header.createdAt, metadata?.lastPromptAt ?? 0)`), and `session-not-found` against `history.ts`. The fix's critical path deliberately does not depend on `updatedAt` semantics at all — it is driven by the transport lifecycle, which is gateway-protocol behavior and identical everywhere the plugin runs.

## Deferred follow-ups

- Store-level frame-pump harness (transport injection behind a protocol) to pin the full hello→flag→activation choreography end-to-end; the decision matrix and the store-level push/error behaviors are already covered.
- A failed *first-baseline* fetch currently retries only on the next activation/hello.
- `historySyncedActivityDates` anchoring nuance documented at its write site.

---
Reviewed locally via a multi-model gate (11 rounds across the two feature cycles; final verdicts APPROVE, no open blockers).