### PR TITLE
fix(ios): stop stack overflow when measuring long assistant messages

### DIFF
--- a/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
+++ b/DeepSeekHarnessMobileTests/GatewayProtocolTests.swift
@@ -5942,3 +5942,60 @@ private final class BackgroundTaskApplicationSpy: BackgroundTaskApplication {
         endedIdentifiers.append(identifier)
     }
 }
+
+/// Regression coverage for a launch-time crash on a physical device.
+///
+/// A completed assistant message is premeasured by hosting the real view
+/// (`ConversationViewportController.measureHostedHeight`). MarkdownUI built its
+/// inline `Text` with a left-associative `result = result + next` chain, so a
+/// single paragraph holding N inline nodes produced a concatenation tree of
+/// depth N. SwiftUI resolves `ConcatenatedTextStorage` recursively, so once a
+/// session contained a long message — one inline node per line — resolution
+/// overflowed the main thread's stack:
+///
+///   EXC_BAD_ACCESS (SIGSEGV) — "Thread stack size exceeded due to excessive
+///   recursion" — Text.resolve ⇄ ConcatenatedTextStorage.resolve
+///
+/// These tests fail by killing the test process before the fix, and must return
+/// a finite measurement after it.
+final class MarkdownLargeMessageTests: XCTestCase {
+    private func longMessage(lineCount: Int) -> String {
+        (1...lineCount).map(String.init).joined(separator: "\n")
+    }
+
+    @MainActor
+    func testMeasuringVeryLongSingleParagraphMessageIsStable() {
+        let host = UIHostingController(
+            rootView: MarkdownContent(longMessage(lineCount: 20000))
+        )
+
+        let size = host.sizeThatFits(
+            in: CGSize(width: 390, height: CGFloat.greatestFiniteMagnitude)
+        )
+
+        XCTAssertTrue(size.height.isFinite, "measurement produced a non-finite height")
+        XCTAssertGreaterThan(size.height, 0)
+    }
+
+    @MainActor
+    func testMeasuringAssistantRowWithVeryLongMessageIsStable() {
+        let item = ConversationItem(
+            id: "very-long-assistant",
+            kind: .assistant,
+            title: "Agent",
+            text: longMessage(lineCount: 20000),
+            isError: false,
+            date: Date(timeIntervalSince1970: 1)
+        )
+        let host = UIHostingController(
+            rootView: ConversationRow(item: item, showsCopyButton: true, imageData: { _ in nil })
+        )
+
+        let size = host.sizeThatFits(
+            in: CGSize(width: 390, height: CGFloat.greatestFiniteMagnitude)
+        )
+
+        XCTAssertTrue(size.height.isFinite, "measurement produced a non-finite height")
+        XCTAssertGreaterThan(size.height, 0)
+    }
+}

--- a/Vendor/swift-markdown-ui/Sources/MarkdownUI/Renderer/TextInlineRenderer.swift
+++ b/Vendor/swift-markdown-ui/Sources/MarkdownUI/Renderer/TextInlineRenderer.swift
@@ -77,7 +77,44 @@ extension Sequence where Element == InlineNode {
 }
 
 private struct TextInlineRenderer {
-  var result = Text("")
+  /// Inline fragments in document order. They are combined only when `result` is
+  /// read, so the concatenation tree can stay balanced (see `balanced(_:)`).
+  private var fragments: [Text] = []
+
+  var result: Text { Self.balanced(self.fragments) }
+
+  /// SwiftUI resolves a concatenated `Text` recursively, so the left-associative
+  /// chain this renderer used to build (`result = result + next`) cost one stack
+  /// frame per inline fragment. A single long paragraph — a few thousand inline
+  /// nodes — then overflowed the main thread's stack while the view was being
+  /// measured, which crashed the app on launch once a session contained a long
+  /// message:
+  ///
+  ///   EXC_BAD_ACCESS (SIGSEGV), "Thread stack size exceeded due to excessive
+  ///   recursion" in `Text.resolve` ⇄ `ConcatenatedTextStorage.resolve`
+  ///
+  /// Combining neighbouring fragments level by level keeps the fragment order and
+  /// the rendered result identical while bounding the resolve depth to O(log n)
+  /// instead of O(n).
+  private static func balanced(_ fragments: [Text]) -> Text {
+    if fragments.isEmpty { return Text("") }
+    var level = fragments
+    while level.count > 1 {
+      var next: [Text] = []
+      next.reserveCapacity((level.count + 1) / 2)
+      var index = 0
+      while index < level.count {
+        if index + 1 < level.count {
+          next.append(level[index] + level[index + 1])
+        } else {
+          next.append(level[index])
+        }
+        index += 2
+      }
+      level = next
+    }
+    return level[0]
+  }
 
   private let baseURL: URL?
   private let textStyles: InlineTextStyles
@@ -160,7 +197,7 @@ private struct TextInlineRenderer {
 
   private mutating func renderImage(_ source: String) {
     if let image = self.images[source] {
-      self.result = self.result + Text(image)
+      self.fragments.append(Text(image))
     }
   }
 
@@ -174,16 +211,15 @@ private struct TextInlineRenderer {
       )
     )
     if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, *) {
-      self.result = self.result + text.customAttribute(MarkdownInlineCodeAttribute())
+      self.fragments.append(text.customAttribute(MarkdownInlineCodeAttribute()))
     } else {
-      self.result = self.result + text
+      self.fragments.append(text)
     }
   }
 
   private mutating func defaultRender(_ inline: InlineNode) {
-    self.result =
-      self.result
-      + Text(
+    self.fragments.append(
+      Text(
         inline.renderAttributedString(
           baseURL: self.baseURL,
           textStyles: self.textStyles,
@@ -191,5 +227,6 @@ private struct TextInlineRenderer {
           attributes: self.attributes
         )
       )
+    )
   }
 }


### PR DESCRIPTION
## Symptom

The app crashes on launch — reproducibly, once a session contains a long assistant message:

```
EXC_BAD_ACCESS (SIGSEGV)
"Thread stack size exceeded due to excessive recursion"
Text.resolve ⇄ ConcatenatedTextStorage.resolve   (repeating)
```

## Cause

A completed assistant message is premeasured by hosting the real view
(`ConversationViewportController.prewarmHeights` → `measureHeight` → `measureHostedHeight` →
`UIHostingController.sizeThatFits`).

MarkdownUI's `TextInlineRenderer` built its inline `Text` with a left-associative chain:

```swift
self.result = self.result + Text(…)
```

`Text + Text` nests one `ConcatenatedTextStorage` level per fragment, and SwiftUI resolves that
structure recursively — so a paragraph holding N inline nodes costs N stack frames. A reply with a
few thousand inline nodes (for example a long numbered list, one node per line) overflows the main
thread's 1 MB stack while the view is being measured.

## Fix

Accumulate the fragments in document order and combine them level by level, so the concatenation
tree is balanced. Fragment order and the rendered result are unchanged; resolve depth becomes
O(log n) instead of O(n).

## Tests

New `MarkdownLargeMessageTests` hosts a 20 000-line message through the real views (both
`MarkdownContent` and `ConversationRow`) and asserts a finite measurement.

- before the change: **the test process crashes** (`Restarting after unexpected exit, crash`), with
  the same `Text.resolve ⇄ ConcatenatedTextStorage.resolve` recursion in the simulator crash report
- after: passes, and the full iOS suite is **139/139**

Verified on a physical device (iPhone 16 Pro, iOS 27.0): the app previously died seconds after
launch, and now launches, stays running and reconnects with its stored device token.

## Note

The change is in the vendored `Vendor/swift-markdown-ui` copy, so the same fix may also be worth
sending to swift-markdown-ui upstream.
