### PR TITLE
fix: recover transport from conversation-lane failures; keep -53 out of the UI

### DIFF
--- a/DeepSeekHarnessMobile/Core/AppStore.swift
+++ b/DeepSeekHarnessMobile/Core/AppStore.swift
@@ -1962,14 +1962,20 @@ final class AppStore: ObservableObject {
         if event.type == "turn/end" {
             backgroundExecutionController.turnEnded(sessionID: record.sessionId)
         }
-        if event.type == "turn/end", record.sessionId == selectedSessionId {
+        // These two are convenience refreshes fired on every turn end, not
+        // user-initiated requests. Passing the live `isConnected` straight into
+        // KMP makes it return `rejected("not-connected", ...)` whenever the
+        // socket happens to be mid-reconnect, which surfaces a modal error for
+        // a refresh nobody asked for. Gate like refreshSessionControls does:
+        // skip while disconnected (the data is re-fetched on reconnect).
+        if event.type == "turn/end", record.sessionId == selectedSessionId, gateway.state.isConnected {
             dispatchSessionControl(.requestContextUsage(
                 sessionID: record.sessionId,
-                isConnected: gateway.state.isConnected
+                isConnected: true
             ))
             dispatchSessionControl(.requestSessionStats(
                 sessionID: record.sessionId,
-                isConnected: gateway.state.isConnected
+                isConnected: true
             ))
         }
         if event.type == "permission/preset",

--- a/DeepSeekHarnessMobile/Core/GatewayClient.swift
+++ b/DeepSeekHarnessMobile/Core/GatewayClient.swift
@@ -166,7 +166,15 @@ final class GatewayClient: ObservableObject {
     /// reconnect loop. A successful `hello` clears recovery mode.
     func applicationDidBecomeActive() {
         isApplicationInBackground = false
-        guard wantsConnection, !state.isConnected, let endpoint else { return }
+        // Also require that no attempt is already in flight. scenePhase `.active`
+        // can be delivered more than once in quick succession (app switcher,
+        // system banners). Without this guard each extra delivery ran
+        // beginConnection() -> disconnect(), cancelling a socket that was still
+        // completing its handshake: the server saw a connect followed ~60ms
+        // later by an abrupt close with no close frame (1006), and URLSession
+        // surfaced ECONNABORTED (-53) to the user. A genuinely stuck attempt is
+        // still bounded by startConnectionTimeout (15s).
+        guard wantsConnection, !state.isConnected, state != .connecting, let endpoint else { return }
         reconnectTask?.cancel()
         reconnectTask = nil
         beginConnection(
@@ -666,7 +674,14 @@ final class GatewayClient: ObservableObject {
         }
         client.onConnectionFailure = { [weak self, weak client] detail in
             guard let self, self.conversationClient === client else { return }
-            self.fail(detail, shouldReconnect: false)
+            // `shouldReconnect: false` sets wantsConnection = false on the whole
+            // transport, after which applicationDidBecomeActive() refuses to
+            // reconnect (`guard wantsConnection`) and no retry is ever scheduled.
+            // One conversation-lane hiccup therefore left the app frozen until
+            // the user relaunched it or reconnected by hand. Recover instead:
+            // the control channel re-opens the conversation lane on its next
+            // hello, and the retry schedule is bounded (2s..30s).
+            self.fail(detail, shouldReconnect: true)
         }
         // 长期凭据已在控制连接 paired 帧中保存，绝不重复使用一次性配对码。
         client.connect(to: endpoint.absoluteString)


### PR DESCRIPTION
## 目的

修复移动端 App 连接/状态生命周期里的三个客户端缺陷。三个都是在**真实网关**（`dsh-plugin-mobile-gateway` 0.7.3）＋一台 iPhone 上稳定复现的，并且每条都有**网关侧日志**作为对照证据。

## 1. `session-stats` 报 `not-connected`，但请求其实已经送达并被正确应答

**现象**：从后台切回 App 时必弹 `KMP SessionControl失败 (not-connected): session-stats`。

**证据（网关侧）**：同一次会话里 7 次 `session-stats` **全部到达网关，且全部在 5–18 ms 内应答成功**。用户报错那一次的时间戳精确对应：

```
[17:57:56.145] client connected  (id=7) channel=control    <- 切回前台
[17:57:56.271] session-stats received: id=7 channel=control session=...
[17:57:56.277] query ok: history                           <- 6 ms 后应答完毕
```

**根因**：`AppStore` 的 `turn/end` 分支把**实时的** `gateway.state.isConnected` 直接传给 KMP；`SharedSessionControlStore.request()` 在它为 false 时返回 `rejected("not-connected", kind)`，再经 `reportNegativeSessionControlResponse` 变成一个用户可见的弹窗——而这只是一次没人主动触发的自动刷新。

**修法**：按同一文件里 `refreshSessionControls` 已有的写法先守门，守门后再传 `true`。

## 2. 一次 conversation lane 故障会**永久**关掉整个传输的重连

**现象**：界面卡住不再更新，**必须杀掉 App 重开**或手动点"连接"才能恢复。

**根因**：`client.onConnectionFailure` 对控制连接调用 `fail(detail, shouldReconnect: false)`，而 `fail` 里有 `if !shouldReconnect { wantsConnection = false }`。之后：

```swift
func applicationDidBecomeActive() {
    guard wantsConnection, !state.isConnected, let endpoint else { return }   // wantsConnection 已为 false → 直接返回
```

全文件只有三处会把 `wantsConnection` 设回 true（`beginConnection` / `disconnect(reconnect:)` / `suspendTransportForBackground`），而回前台这条路被挡住；`fail` 里也不会安排重连任务（`guard shouldReconnect, channel == "control"`）。

**修法**：改为重连（`shouldReconnect: true`）。控制通道会在下一次 `hello` 时重新打开 conversation lane，退避是有界的（2s…30s）。

## 3. 回前台处理可重入，会取消正在握手的 socket

**现象**：切回 App 时偶发 `WebSocket连接失败: 未能完成该操作。软件导致连接中止 (NSPOSIXErrorDomain 53)`。

**证据（网关侧）**：失败那一刻的连接全部以 `code=1006`（无 close 帧的异常断开）结束，其中一条只活了 **58 ms**、`frames=0`；而同一台手机在 2 分钟前还能稳定保持 **159 秒**、收到 33 帧。网关保活误杀 0 次、nginx 该时段错误日志为空、frps 正常转发——所以不是服务端或链路主动断的。

**根因**：`scenePhase == .active` 可能连续投递多次。`applicationDidBecomeActive()` 没有检查"是否已有连接尝试在进行中"，于是每次多余投递都执行 `beginConnection()` → `disconnect()`，把**仍在握手**的 socket 取消掉，客户端因此拿到 ECONNABORTED。

**修法**：`state == .connecting` 时跳过。真正卡住的尝试仍由 `startConnectionTimeout`（15 s）兜底。

## 验证状态（重要）

- ✅ 补丁格式已校验（`git apply --check`），改动仅限两个文件。
- ✅ 三条根因都能在源码里定位到具体行，并有网关日志作为对照。
- ⚠️ **本补丁未在本机编译或运行**（在 Windows 上通过阅读源码完成，无 Xcode）。
- ⚠️ 第 3 条的因果链是**推断**：代码能证明"重复 `.active` 会取消握手中的 socket"，日志能证明"确实出现过连接后 58 ms 被异常断开"，但没有真机打点证明这两者是同一事件。
- ⚠️ 合并前建议跑现有门禁：`./gradlew :shared:allTests`，以及 iPhone Simulator 的 `GatewayProtocolTests`。

## 未改动的一处（说明理由）

`activatePreparedConversation` 在 `gateway.state.isConnected` 为 false 时提前 return，因此**不会订阅**。但新建立的连接 `filterSessionId` 默认为空＝接收所有会话，看起来这种情况会自愈；且没有证据把它与观察到的"订阅停在别的会话"现象关联起来。**没有证据的语义改动不做。**

## 影响面

仅连接生命周期与一次自动刷新的守门；不涉及协议、数据结构或 UI 结构。
